### PR TITLE
Add social media preview meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ description: "Keep your mind sharp and active with our collection of brain games
 keywords: "free mobile games for brain, brain games app, best mind games android, best mobile games for your brain, free mobile brain games"
 skills: "Keep your mind sharp and active with our collection of serious games!"
 meta_author: Mobile Brain Games
+social_image: img/profile.png
 
 # Google webmaster tools
 google_verify:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,21 @@
   <meta name="keywords" content="{{ site.keywords }}" />
   {% if site.meta_author %}
   <meta name="author" content="{{ site.meta_author }}">{% endif %}
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ site.url }}">
+  <meta property="og:title" content="{{ site.title }}">
+  <meta property="og:description" content="{{ site.description }}">
+  <meta property="og:image" content="{{ site.url }}{{ site.social_image }}">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="{{ site.url }}">
+  <meta property="twitter:title" content="{{ site.title }}">
+  <meta property="twitter:description" content="{{ site.description }}">
+  <meta property="twitter:image" content="{{ site.url }}{{ site.social_image }}">
+
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="feed.xml">
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.baseurl }}/img/fav.png">


### PR DESCRIPTION
I have added Open Graph and Twitter meta tags to your website. This will ensure that when you share the link on social media, it uses your main logo (`img/profile.png`) and the correct title and description, instead of picking an image from one of the individual games.

I've also added a `social_image` setting in your `_config.yml` file, so you can easily change the social media image in the future if you wish.

---
*PR created automatically by Jules for task [3805356234976724077](https://jules.google.com/task/3805356234976724077) started by @Thelouras58*