### PR TITLE
Fix 404 error for Flutter app integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,8 +63,8 @@ defaults:
     values:
       permalink: ""
 
-# Tell Jekyll not to process the Flutter folder
-exclude:
+# Ensure Jekyll includes the Flutter folder but doesn't process it as Liquid
+include:
   - numbergameforkids
 
 # Ensure Jekyll doesn't delete the folder during build


### PR DESCRIPTION
The issue was caused by the 'exclude' setting in _config.yml, which told Jekyll to ignore the 'numbergameforkids' folder during the site build. As a result, the folder was not included in the deployed site, leading to a 404 error.

I have updated _config.yml to:
1. Remove 'numbergameforkids' from 'exclude'.
2. Add 'numbergameforkids' to 'include' to ensure it is always part of the build output, even if it contains files Jekyll might otherwise ignore.
3. Keep 'numbergameforkids' in 'keep_files' to ensure it's not deleted during incremental builds (as per the user's previous instructions).

I verified the fix by building the site locally and using a Playwright script to confirm that the app loads correctly and shows the 'QuickMath Core' title and UI.

---
*PR created automatically by Jules for task [8222351368159868496](https://jules.google.com/task/8222351368159868496) started by @Thelouras58*