### PR TITLE
Fix broken SEO canonical links and metadata URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: Mobile Brain Games 
 email: hello@mobilebraingames.com
-url: https://mobilebraingames.com/
+url: https://mobilebraingames.com
 description: "Keep your mind sharp and active with our collection of brain games!"
 keywords: "free mobile games for brain, brain games app, best mind games android, best mobile games for your brain, free mobile brain games"
 skills: "Keep your mind sharp and active with our collection of serious games!"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,19 +10,19 @@
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ site.url }}">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
   <meta property="og:title" content="{{ site.title }}">
   <meta property="og:description" content="{{ site.description }}">
-  <meta property="og:image" content="{{ site.url }}{{ site.social_image }}">
+  <meta property="og:image" content="{{ site.social_image | absolute_url }}">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="{{ site.url }}">
+  <meta property="twitter:url" content="{{ page.url | absolute_url }}">
   <meta property="twitter:title" content="{{ site.title }}">
   <meta property="twitter:description" content="{{ site.description }}">
-  <meta property="twitter:image" content="{{ site.url }}{{ site.social_image }}">
+  <meta property="twitter:image" content="{{ site.social_image | absolute_url }}">
 
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="RSS" href="feed.xml">
   <link rel="shortcut icon" type="image/x-icon" href="{{ site.baseurl }}/img/fav.png">
 <!--   <link rel="shortcut icon" type="image/png" href="favicon.png"> -->


### PR DESCRIPTION
This PR fixes an SEO issue where canonical links were being generated with double slashes (e.g., `https://mobilebraingames.com//`). 

The fix involves:
1.  **Updating `_config.yml`**: Removed the trailing slash from `site.url`.
2.  **Improving `_includes/head.html`**: Replaced manual URL construction with the robust `absolute_url` Liquid filter for the `canonical` tag, as well as for Open Graph and Twitter metadata tags. This ensures that subpages also correctly report their own URLs instead of the site root.

These changes improve search engine indexability and social sharing accuracy.

---
*PR created automatically by Jules for task [6179594467730924530](https://jules.google.com/task/6179594467730924530) started by @Thelouras58*