### PR TITLE
Fix mobile layout overflow from long button text

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -9,7 +9,7 @@
     </div>
       <div class="row" style="margin-bottom: 30px;">
       <div class="col-lg-12 text-center">
-        <a href="https://play.google.com/store/apps/details?id=mobile.brain.games.mobile_brain_games_premium" class="btn btn-lg btn-success" style="font-size: 24px; padding: 15px 30px; border-radius: 10px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+        <a href="https://play.google.com/store/apps/details?id=mobile.brain.games.mobile_brain_games_premium" class="btn btn-lg btn-success" style="font-size: 24px; padding: 15px 30px; border-radius: 10px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); white-space: normal; word-wrap: break-word;">
           <i class="fab fa-google-play"></i> Mobile Brain Games Premium
         </a>
       </div>


### PR DESCRIPTION
Fixes a horizontal scrolling issue on mobile browsers.

The newly added 'Mobile Brain Games Premium' button utilized Bootstrap's `.btn` class, which has `white-space: nowrap` by default. This caused long strings to overflow the screen horizontally on smaller viewports (like iOS mobile browsers), forcing the entire website into horizontal scrolling mode.

Adding `white-space: normal;` and `word-wrap: break-word;` to the button's inline style rectifies the issue by allowing the text to safely wrap to a new line on smaller screens, keeping the original aesthetic while maintaining a fixed-width viewport layout.

---
*PR created automatically by Jules for task [7528857144747522955](https://jules.google.com/task/7528857144747522955) started by @Thelouras58*