### PR TITLE
Update hero subtitle text to fix duplicate content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ url: https://mobilebraingames.com
 lang: en
 description: "Explore puzzle, memory, word, and reaction games from Mobile Brain Games."
 keywords: "brain games, memory games, puzzle games, word games, reaction games"
-skills: "Over 80,000 downloads for all the games of the collection."
+skills: "Over 80,000 downloads across the collection"
 meta_author: Mobile Brain Games
 social_image: img/profile.png
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ url: https://mobilebraingames.com
 lang: en
 description: "Explore puzzle, memory, word, and reaction games from Mobile Brain Games."
 keywords: "brain games, memory games, puzzle games, word games, reaction games"
-skills: "Games for memory, patterns, words, reaction time, and quick thinking."
+skills: "Over 80,000 downloads for all the games of the collection."
 meta_author: Mobile Brain Games
 social_image: img/profile.png
 


### PR DESCRIPTION
This PR updates the subtitle text displayed in the website hero header. Previously, the subtitle repeated the main heading content. It now reads: "Over 80,000 downloads for all the games of the collection."

---
*PR created automatically by Jules for task [1098645748319859049](https://jules.google.com/task/1098645748319859049) started by @Thelouras58*